### PR TITLE
Movement speed no longer determined by camera angle

### DIFF
--- a/Assets/Scenes/TC Scene #2.unity
+++ b/Assets/Scenes/TC Scene #2.unity
@@ -855,7 +855,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   moveSpeed: 10
-  rotationSpeed: 2000
+  rotationSpeed: 6
   playerModel: {fileID: 740938812}
   groundDetector: {fileID: 116146051}
 --- !u!114 &829924076

--- a/Assets/Scenes/TC Scene #2.unity.meta
+++ b/Assets/Scenes/TC Scene #2.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 553006c8145d23a4abcb9d3164601a7d
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -40,7 +40,7 @@ public class PlayerMovement : MonoBehaviour
     private void Update()
     {
         var finalMovement = CalculateMovementVector();
-        controller.Move(finalMovement);
+        controller.Move(moveSpeed * Time.deltaTime * finalMovement);
         RotatePlayerGFX(finalMovement);
 
 
@@ -65,8 +65,8 @@ public class PlayerMovement : MonoBehaviour
             targetRotation.x = 0;
             targetRotation.z = 0;
 
-            //float step = rotationSpeed / Quaternion.Angle(playerModel.transform.rotation, targetRotation);
-            playerModel.transform.rotation = Quaternion.Lerp(playerModel.transform.rotation, targetRotation, Time.deltaTime);
+            // float step = rotationSpeed / Quaternion.Angle(playerModel.transform.rotation, targetRotation);
+            playerModel.transform.rotation = Quaternion.Lerp(playerModel.transform.rotation, targetRotation, Time.deltaTime * rotationSpeed);
         }
     }
 
@@ -76,10 +76,10 @@ public class PlayerMovement : MonoBehaviour
         // note: movement.y is the forward/backward input because we are converting value.Get<Vector2>() directly to a Vector3
         Vector3 camForward = cam.transform.forward;
         camForward.y = 0f;
+        camForward.z = camForward.z > 0 ? 1 : -1;
         Vector3 forwardMovement = movement.y * camForward;
         Vector3 rightMovement = movement.x * cam.transform.right;
-        Vector3 finalMovement = (forwardMovement + rightMovement) * moveSpeed * Time.deltaTime;
-        Debug.Log("Forward: " + forwardMovement + ", Right: " + rightMovement + ", Final: " + finalMovement);
+        Vector3 finalMovement = (forwardMovement + rightMovement);
 
         return finalMovement;
     }


### PR DESCRIPTION
## Scene Changes
`TC Scene #2`

![image](https://github.com/javajon13/Wanderer/assets/25230663/8b00c5c7-532d-4ec6-8431-3b1502532805)
Reduced rotation speed for the player LERP since we are no longer using the step calculation

## Code Changes
`PlayerMovement.cs`

Reference my code changes below. The biggest issue was that normalization would result in a *magnitude* of 1, but not guarantee that each portion of the vector was "rounded up" to 1 or -1 as the case may be. So all we do now is look at the Z direction of the `camForward` vector, and force it to be 1 or -1 if it's nonzero. We also strip away the `time.DeltaTime` and `movementSpeed` scalars and keep those on the Update loops Move call for the character controller